### PR TITLE
👍🏽 Enable building on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - node
+sudo: false


### PR DESCRIPTION
Previously the rapid7/warden travis build was consistently failing due
to not having a Rakefile (Travis assumes Ruby is no .travis.yml is
provided).