### PR TITLE
Separate cookbook and build gem dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,8 @@ vendor/
 .idea/
 
 cookbook/metadata.json
+
+# Build artifacts
+*.tar.gz
+*.tgz
+npm-shrinkwrap.json

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,11 @@
 source 'https://rubygems.org'
 
-gem 'builderator', '~> 1.0'
 gem 'rake', '~> 10.5'
 gem 'fpm', '~> 1.6'
 gem 'sinatra', '~> 1.4'
 gem 'sinatra-json', '~> 0.1'
 gem 'octokit', '~> 4.0'
+
+group :cookbook do
+  gem 'builderator', '~> 1.0'
+end


### PR DESCRIPTION
This PR defines a `:cookbook` group so we can use the `--without` flag when we want to `bundle install` and not have to wait forever for `dep-selector-libgecode` to install.