### PR TITLE
Make Rakefile great again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,8 @@ vendor/
 .idea/
 
 cookbook/metadata.json
+
+# Build artifacts
+*.tar.gz
+*.tgz
+npm-shrinkwrap.json

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,11 @@
 source 'https://rubygems.org'
 
-gem 'builderator', '~> 1.0'
 gem 'rake', '~> 10.5'
 gem 'fpm', '~> 1.6'
 gem 'sinatra', '~> 1.4'
 gem 'sinatra-json', '~> 0.1'
 gem 'octokit', '~> 4.0'
+
+group :cookbook do
+  gem 'builderator', '~> 1.0'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,3 @@ gem 'octokit', '~> 4.0'
 group :cookbook do
   gem 'builderator', '~> 1.0'
 end
-
-group :pkcs7 do
-  gem 'sinatra', '~> 1.4'
-  gem 'sinatra-json', '~> 0.1'
-end

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,15 @@
 source 'https://rubygems.org'
 
 gem 'rake', '~> 10.5'
+gem 'aws-sdk', '~> 2.2'
 gem 'fpm', '~> 1.6'
-gem 'sinatra', '~> 1.4'
-gem 'sinatra-json', '~> 0.1'
 gem 'octokit', '~> 4.0'
 
 group :cookbook do
   gem 'builderator', '~> 1.0'
+end
+
+group :pkcs7 do
+  gem 'sinatra', '~> 1.4'
+  gem 'sinatra-json', '~> 0.1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -262,6 +262,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk (~> 2.2)
   builderator (~> 1.0)
   fpm (~> 1.6)
   octokit (~> 4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,8 +176,6 @@ GEM
     plist (3.1.0)
     proxifier (1.0.3)
     rack (1.6.4)
-    rack-protection (1.5.3)
-      rack
     rake (10.5.0)
     retryable (2.0.4)
     ridley (4.6.1)
@@ -230,13 +228,6 @@ GEM
       rspec-its
       specinfra (~> 2.53)
     sfl (2.2)
-    sinatra (1.4.7)
-      rack (~> 1.5)
-      rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
-    sinatra-json (0.1.0)
-      multi_json (~> 1.0)
-      sinatra (~> 1.0)
     solve (2.0.3)
       molinillo (~> 0.4.2)
       semverse (~> 1.1)
@@ -249,7 +240,6 @@ GEM
     syslog-logger (1.6.8)
     systemu (2.6.5)
     thor (0.19.1)
-    tilt (2.0.5)
     timers (4.0.4)
       hitimes
     uuidtools (2.1.5)
@@ -267,8 +257,6 @@ DEPENDENCIES
   fpm (~> 1.6)
   octokit (~> 4.0)
   rake (~> 10.5)
-  sinatra (~> 1.4)
-  sinatra-json (~> 0.1)
 
 BUNDLED WITH
    1.13.1

--- a/Rakefile
+++ b/Rakefile
@@ -125,7 +125,8 @@ task :deb => [:chdir_pkg, :source] do
   sh command
 end
 
-task :upload_packages => [:deb] do
+task :upload_packages do
+  cd pkg_dir
   mkdir 'copy_to_s3'
   deb = Dir["#{name}_#{version}_*.deb"].first
   cp deb, 'copy_to_s3/'
@@ -137,7 +138,7 @@ task :upload_packages => [:deb] do
 end
 
 desc "Release #{name} and prepare to create a release on github.com"
-task :release => [:package] do
+task :release do
   puts
   puts "Create a new #{version} release on github.com and upload the #{name} tarball"
   puts 'You can find directions here: https://github.com/blog/1547-release-your-software'
@@ -178,3 +179,4 @@ CLEAN.include '**/.DS_Store'
 CLEAN.include 'node_modules/'
 
 task :default => [:clean, :package, :release]
+task :upload => [:clean, :package, :upload_packages]

--- a/Rakefile
+++ b/Rakefile
@@ -137,12 +137,12 @@ task :upload_packages => [:deb] do
 end
 
 desc "Release #{name} and prepare to create a release on github.com"
-task :release do
+task :release => [:package] do
   puts
   puts "Create a new #{version} release on github.com and upload the #{name} tarball"
   puts 'You can find directions here: https://github.com/blog/1547-release-your-software'
-  puts
   puts 'Make sure you add release notes!'
+
   cp ::File.join(base_dir, "#{name}-#{version}.tgz"), pkg_dir
 
   begin
@@ -167,6 +167,9 @@ task :release do
   compare_url = "#{github_repo.url}/compare/#{latest_release.name}...#{release.name}"
   puts "You can find a diff between this release and the previous one here: #{compare_url}"
 end
+
+desc "Package #{name}"
+task :package => [:install, :shrinkwrap, :pack, :deb]
 
 CLEAN.include 'npm-shrinkwrap.json'
 CLEAN.include "#{name}-*.tgz"

--- a/Rakefile
+++ b/Rakefile
@@ -94,7 +94,7 @@ task :package_dirs do
   mkdir_p ::File.join(base_dir, config_dir)
 end
 
-task :warden_source => [:install] do
+task :source => [:install] do
   ['bin/', 'lib/', 'node_modules/', 'LICENSE', 'package.json', 'pkcs7/'].each do |src|
     cp_r ::File.join(base_dir, src), ::File.join(base_dir, install_dir)
   end
@@ -105,7 +105,7 @@ task :chdir_pkg => [:package_dirs] do
   cd pkg_dir
 end
 
-task :deb => [:chdir_pkg, :warden_source] do
+task :deb => [:chdir_pkg, :source] do
   command = [
     'bundle',
     'exec',

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
 require 'json'
 require 'fileutils'
 require 'mkmf'
+require 'aws-sdk'
+require 'logger'
 require 'rake/clean'
 require 'octokit'
 
@@ -8,6 +10,7 @@ include FileUtils
 
 CLIENT_ID = ENV['GITHUB_CLIENT_ID']
 CLIENT_TOKEN = ENV['GITHUB_CLIENT_TOKEN']
+ARTIFACT_BUCKET = ENV['ARTIFACT_BUCKET']
 
 def package_json
   @package_json ||= JSON.parse(File.read('package.json'))
@@ -122,8 +125,16 @@ task :deb => [:chdir_pkg, :warden_source] do
   sh command
 end
 
-desc "Package #{name}"
-task :package => [:install, :shrinkwrap, :pack, :deb]
+task :upload_packages => [:deb] do
+  mkdir 'copy_to_s3'
+  deb = Dir["#{name}_#{version}_*.deb"].first
+  cp deb, 'copy_to_s3/'
+  s3 = Aws::S3::Resource.new(region: 'us-east-1', logger: Logger.new(STDOUT))
+  Dir["copy_to_s3/**/#{name}*"].each do |package|
+    upload_package = ::File.basename(package)
+    s3.bucket(ARTIFACT_BUCKET).object("#{name}/#{upload_package}").upload_file(package)
+  end
+end
 
 desc "Release #{name} and prepare to create a release on github.com"
 task :release do


### PR DESCRIPTION
This PR makes Rakefile tasks more consistent across the Spectre services. It was branched off of [gem-groups](https://github.com/rapid7/warden/tree/gem-groups) but while it could be merged now, we should wait until #44 is merged just to make sure the intent of both pull requests is respected.