### PR TITLE
Fix broken test

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -60,8 +60,8 @@ process.on('exit', function() {
   signatureServer.stop();
 });
 
-server.on('error', (err) => global.Log.error(err));
+server.on('error', (err) => global.Log.log('error', err));
 
 server.listen(port, host, () => {
-  Log.info(`Listening on ${host}:${port}`);
+  Log.log('info', `Listening on ${host}:${port}`);
 });

--- a/lib/control/v1/authenticate.js
+++ b/lib/control/v1/authenticate.js
@@ -18,7 +18,7 @@ function Authenticate(app, server) {
 
   app.post('/v1/authenticate',
     (req, res, next) => {
-      Log.debug('authenticate request recieved');
+      Log.log('debug', 'authenticate request recieved');
       if (!Config.get('vault:token')){
         return bad.request(res, 'Vault is sealed! Use the /v1/unseal API.');
       };

--- a/lib/control/v1/signature.js
+++ b/lib/control/v1/signature.js
@@ -22,28 +22,28 @@ class Server {
 
   start() {
     this.process = bundledGemSpawn(this.path, ['-p', this.port], {cwd: Path.resolve(__dirname, '../../../pkcs7')});
-    Log.info(`PKCS7 helper started. PID ${process.pid}. Port ${this.port}`);
+    Log.log('info', `PKCS7 helper started. PID ${process.pid}. Port ${this.port}`);
 
     // Crash/respawn handler
     this.process.on('exit', (code, signal) => {
       if (this.stopped) {
-        Log.info('PKCS7 helper shutdown');
+        Log.log('info', 'PKCS7 helper shutdown');
         return;
       }
 
       this.retries += 1;
-      Log.info('retry attempt '+this.retries);
+      Log.log('info', 'retry attempt '+this.retries);
       if (this.retries > this.maxRetires) {
-        Log.error('PKCS7 helper restart max-retries have been exceeded!');
+        Log.log('error', 'PKCS7 helper restart max-retries have been exceeded!');
         return;
       }
 
-      Log.warn(`PKCS7 helper exited unexpectedly with code ${code}`);
+      Log.log('warn', `PKCS7 helper exited unexpectedly with code ${code}`);
       this.start();
     });
 
     // Capture logging
-    this.process.stdout.on('data', (data) => Log.info(`PKCS7 helper: ${data}`));
+    this.process.stdout.on('data', (data) => Log.log('info', `PKCS7 helper: ${data}`));
   }
 
   stop() {

--- a/lib/control/v1/unseal.js
+++ b/lib/control/v1/unseal.js
@@ -3,20 +3,23 @@
 const bodyParser = require('body-parser');
 
 const HTTP_OK = 200;
+const HTTP_BAD_REQUEST = 400;
 
 function Unseal(app) {
   app.use(bodyParser.json());
 
   app.post('/v1/unseal',
     (req, res, next) => {
-      if (req.body){
+      if (req.body && req.body.hasOwnProperty('token')) {
         Config.set('vault:token', req.body.token);
         Log.log('info', Config.get('vault'));
         return res.status(HTTP_OK).json({
           code: HTTP_OK,
           status: 'Warden token updated to be: '+req.body.token
         });
-      };
+      }
+
+      return res.status(HTTP_BAD_REQUEST).end();
     });
 
 };

--- a/lib/control/v1/unseal.js
+++ b/lib/control/v1/unseal.js
@@ -11,7 +11,7 @@ function Unseal(app) {
     (req, res, next) => {
       if (req.body){
         Config.set('vault:token', req.body.token);
-        Log.info(Config.get('vault'));
+        Log.log('info', Config.get('vault'));
         return res.status(HTTP_OK).json({
           code: HTTP_OK,
           status: 'Warden token updated to be: '+req.body.token

--- a/test/unseal-api-v1.js
+++ b/test/unseal-api-v1.js
@@ -3,6 +3,9 @@
 
 global.Config = require('nconf')
 global.Config.use('memory');
+global.Log = {
+  log: () => { }
+}
 
 const request = require('supertest');
 const expect = require('expect')

--- a/test/unseal-api-v1.js
+++ b/test/unseal-api-v1.js
@@ -16,9 +16,10 @@ const unseal = require('../lib/control/v1/unseal');
 const testServerPort = 3000;
 const HTTP_OK = 200;
 const HTTP_METHOD_NOT_ALLOWED = 405;
-const ERROR = 500;
+const HTTP_BAD_REQUEST = 400;
 
 const good = {token: '12345678-abcd-1234-!@#$-123456789abc'};
+const bad = 'thisisabadbitofposteddata';
 const res = {status() {return this}, json(any) {return any}};
 const next = function() {return true};
 
@@ -57,7 +58,8 @@ describe('unseal API v1', () => {
   it('responds to a malformed request to the /unseal endpoint', (done) => {
     request(server)
       .post('/v1/unseal')
-      .expect(ERROR)
+      .send(bad)
+      .expect(HTTP_BAD_REQUEST)
       .end(done);
   });
 


### PR DESCRIPTION
This PR fixes an issue where the test to check if an error came back from passing `/v1/unseal` invalid data was broken because the endpoint wasn't enforcing the expected behavior.