### PR TITLE
Remove hardcoded settings for token generation in favor of tunables

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,7 +1,9 @@
 {
   "vault": {
     "port": 8200,
-    "hostname": "localhost"
+    "hostname": "localhost",
+    "renewable": true,
+    "ttl": "5m"
   },
   "service": {
     "port": 8705,

--- a/lib/control/validation/token.js
+++ b/lib/control/validation/token.js
@@ -43,8 +43,20 @@ function send(body, ami, vault, callback) {
 exports.send = send;
 
 exports.create = function(req, res, next, vault) {
+  const tokenParams = {
+    renewable: Config.get('vault:renewable'),
+    ttl: Config.get('vault:ttl'),
+    explicit_max_ttl: Config.get('vault:max_ttl'),
+    no_parent: true
+  };
 
-  const tokenParams = {renewable:true, ttl:'5m', no_parent:true};
+  // If any of the tunables don't exist in Config
+  // and return `undefined`, delete them
+  Object.keys(tokenParams).forEach((k) => {
+    if (typeof tokenParams[k] === 'undefined') {
+      delete tokenParams[k];
+    }
+  });
 
   send(tokenParams, req.document.imageId, vault,
     function(err, status) {


### PR DESCRIPTION
Made token settings sent to Vault tunable. This construct also supports a `explicit_max_ttl` config option which enforces a maximum lifetime for a token. Here are the relevant bits from the Vault docs:

> explicit_max_ttl optional If set, the token will have an explicit max TTL set upon it. This maximum token TTL cannot be changed later, and unlike with normal tokens, updates to the system/mount max TTL value will have no effect at renewal time -- the token will never be able to be renewed or used past the value set at issue time.