### PR TITLE
Submit only duration values in seconds to Vault

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -3,7 +3,7 @@
     "port": 8200,
     "hostname": "localhost",
     "renewable": true,
-    "ttl": "300s"
+    "ttl": 300
   },
   "service": {
     "port": 8705,

--- a/lib/control/validation/token.js
+++ b/lib/control/validation/token.js
@@ -32,10 +32,21 @@ function getTokenTiming(accessor, vault) {
 }
 
 exports.create = function(req, res, next, vault) {
+  let ttl = Config.get('vault:ttl'),
+    explicit_max_ttl = Config.get('vault:explicit_max_ttl');
+
+  if (typeof ttl !== 'undefined') {
+    ttl = `${ttl}s`;
+  }
+
+  if (typeof explicit_max_ttl !== 'undefined') {
+    explicit_max_ttl = `${explicit_max_ttl}s`;
+  }
+
   const tokenParams = {
     renewable: Config.get('vault:renewable'),
-    ttl: Config.get('vault:ttl'),
-    explicit_max_ttl: Config.get('vault:explicit_max_ttl'),
+    ttl,
+    explicit_max_ttl,
     no_parent: true
   };
 


### PR DESCRIPTION
This PR appends `s` to the number of seconds specified in the config file for `vault:ttl` and `vault:explicit_max_ttl` if they exist.