### PR TITLE
Configure token creation settings

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -2,8 +2,11 @@
   "vault": {
     "port": 8200,
     "hostname": "localhost",
-    "renewable": true,
-    "ttl": 300
+    "tokenParams": {
+      "renewable": true,
+      "ttl": 300,
+      "no_parent": true
+    }
   },
   "service": {
     "port": 8705,

--- a/lib/control/validation/token.js
+++ b/lib/control/validation/token.js
@@ -32,8 +32,12 @@ function getTokenTiming(accessor, vault) {
 }
 
 exports.create = function(req, res, next, vault) {
-  let ttl = Config.get('vault:ttl'),
-    explicit_max_ttl = Config.get('vault:explicit_max_ttl');
+  const tokenProps = Config.get('vault:tokenParams');
+
+  // ttl and explicit_max_ttl have special handling
+  // rules because they need a duration suffix
+  let ttl = Config.get('vault:tokenParams:ttl'),
+    explicit_max_ttl = Config.get('vault:tokenParams:explicit_max_ttl');
 
   if (typeof ttl !== 'undefined') {
     ttl = `${ttl}s`;
@@ -43,12 +47,7 @@ exports.create = function(req, res, next, vault) {
     explicit_max_ttl = `${explicit_max_ttl}s`;
   }
 
-  const tokenParams = {
-    renewable: Config.get('vault:renewable'),
-    ttl,
-    explicit_max_ttl,
-    no_parent: true
-  };
+  const tokenParams = Object.assign(tokenProps, {ttl, explicit_max_ttl});
 
   // If any of the tunables don't exist in Config
   // and return `undefined`, delete them

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "node ./bin/server.js",
-    "test": "mocha",
+    "test": "mocha --require ./test/init",
     "cover": "rm -Rf coverage/* && istanbul cover _mocha -- -R spec",
     "lint": "eslint bin/* lib/*.js lib/**/*.js test/*.js",
     "report": "coveralls < ./coverage/lcov.info"

--- a/test/init.js
+++ b/test/init.js
@@ -1,0 +1,11 @@
+'use strict';
+
+global.Log = {
+  log() {}
+};
+
+global.Config = require('nconf')
+    .argv()
+    .env()
+    .defaults(require('../config/defaults.json'))
+    .use('memory');

--- a/test/unseal-api-v1.js
+++ b/test/unseal-api-v1.js
@@ -1,11 +1,5 @@
 'use strict';
 
-global.Config = require('nconf');
-global.Config.use('memory');
-global.Log = {
-  log: () => { }
-};
-
 const request = require('supertest');
 const expect = require('expect');
 const should = require('should');


### PR DESCRIPTION
This PR allows us to define a set of parameters in the config object which will be included with the request to Vault's `/v1/auth/token/create` endpoint. This allows us to specify additional metadata, policies, and other nice things.