### PR TITLE
Deprecated use of bundled-gem-spawn

### DIFF
--- a/lib/control/v1/signature.js
+++ b/lib/control/v1/signature.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-const bundledGemSpawn = require('bundled-gem-spawn');
+const spawn = require('child_process').spawn;
 const Path = require('path');
 const send = require('../util').send;
 
@@ -32,7 +32,7 @@ class Server {
    * Start the server
    */
   start() {
-    this.process = bundledGemSpawn(this.path, ['-p', this.port], {cwd: Path.resolve(__dirname, '../../../pkcs7')});
+    this.process = spawn(this.path, ['-p', this.port]);
     Log.log('info', `PKCS7 helper started. PID ${process.pid}. Port ${this.port}`);
 
     // Crash/respawn handler

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "aws-sdk": "~2.3.19",
     "body-parser": "~1.15.0",
-    "bundled-gem-spawn": "~1.0.1",
     "express": "~4.13.4",
     "express-winston": "~2.0.0",
     "nconf": "~0.8.4",


### PR DESCRIPTION
Since the PKCS helper no longer needs to be executed in the context of a bundle, using the `bundled-gem-spawn` package to execute the helper will throw errors and fail to start it.