### PR TITLE
Cookbook: Guard symlink resource

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -53,7 +53,7 @@ def max_version
 end
 
 def install_dir
-  ::File.join('pkg', 'opt', name)
+  ::File.join('pkg', 'opt', "#{name}-#{version}")
 end
 
 def config_dir

--- a/cookbook/metadata.rb
+++ b/cookbook/metadata.rb
@@ -17,3 +17,4 @@ long_description IO.read(::File.join(project_path, 'README.md')) rescue ''
 version package_dot_json.fetch('version', '0.0.1')
 
 depends 'nodejs'
+depends 'ark', '~> 3.0.0'

--- a/cookbook/recipes/default.rb
+++ b/cookbook/recipes/default.rb
@@ -31,10 +31,21 @@ remote_file 'warden' do
   backup false
 end
 
+version_dir = "#{ node['warden']['paths']['directory'] }-#{ node['warden']['version'] }"
+
 package 'warden' do
   source resources('remote_file[warden]').path
   provider Chef::Provider::Package::Dpkg
   version node['warden']['version']
+
+  notifies :create, "link[#{node['warden']['paths']['directory']}]", :immediately
+end
+
+link node['warden']['paths']['directory'] do
+  to version_dir
+
+  action :nothing
+  notifies :restart, 'service[warden]' if node['warden']['enable']
 end
 
 ## Upstart Service


### PR DESCRIPTION
This PR adds a notification guard to the symlink resource so nothing gets linked unless the service is installed.

In addition, it makes the installation path and process more consistent with the rest of Spectre.